### PR TITLE
Support for tags, pagination and sections

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -50,7 +50,7 @@
         <div class="content container">
             {% block content %}
                 <div class="posts">
-                    {% for page in section.pages | reverse %}
+					{% for page in paginator.pages %}
                       <div class="post">
                         <h1 class="post-title">
                           <a href="{{ page.permalink }}">
@@ -62,6 +62,18 @@
                       </div>
                     {% endfor %}
                 </div>
+
+				<nav>
+					<p>
+						{% if paginator.previous %}
+							<a href="{{ paginator.previous }}">&laquo; Previous</a> |
+						{% endif %}
+						<span>Page {{ paginator.current_index }} of {{ paginator.number_pagers }}</span>
+						{% if paginator.next %}
+							| <a href="{{ paginator.next }}"> Next &raquo;</a>
+						{% endif %}
+					</p>
+				</nav>
             {% endblock content %}
         </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,16 +31,16 @@
                         {% block sidebar_about %}
                             <a href="{{ config.base_url }}"><h1>{{ config.title }}</h1></a>
                             {% if config.description %}
-                            <p class="lead">{{config.description}}</p>
+                                <p class="lead">{{config.description}}</p>
                             {% endif %}
                         {% endblock sidebar_about %}
                     </div>
 
                     <ul class="sidebar-nav">
                         {% block sidebar_nav %}
-                        {% for link in config.extra.hyde_links %}
-                        <li class="sidebar-nav-item"><a href="{{link.url}}">{{link.name}}</a></li>
-                        {% endfor %}
+                            {% for link in config.extra.hyde_links %}
+                                <li class="sidebar-nav-item"><a href="{{link.url}}">{{link.name}}</a></li>
+                            {% endfor %}
                         {% endblock sidebar_nav %}
                     </ul>
                 </div>
@@ -50,30 +50,32 @@
         <div class="content container">
             {% block content %}
                 <div class="posts">
-					{% for page in paginator.pages %}
-                      <div class="post">
-                        <h1 class="post-title">
-                          <a href="{{ page.permalink }}">
-                            {{ page.title }}
-                          </a>
-                        </h1>
+                    {% for page in paginator.pages %}
+                        <div class="post">
+                            <h1 class="post-title">
+                                <a href="{{ page.permalink }}">
+                                    {{ page.title }}
+                                </a>
+                            </h1>
 
-                        <span class="post-date">{{ page.date | date(format="%Y-%m-%d") }}</span>
-                      </div>
-                    {% endfor %}
+                            <span class="post-date">{{ page.date | date(format="%Y-%m-%d") }}</span>
+                        </div>
+                        {% endfor %}
                 </div>
 
-				<nav>
-					<p>
-						{% if paginator.previous %}
-							<a href="{{ paginator.previous }}">&laquo; Previous</a> |
-						{% endif %}
-						<span>Page {{ paginator.current_index }} of {{ paginator.number_pagers }}</span>
-						{% if paginator.next %}
-							| <a href="{{ paginator.next }}"> Next &raquo;</a>
-						{% endif %}
-					</p>
-				</nav>
+                <nav>
+                    <p>
+                        {% if paginator.previous %}
+                            <a href="{{ paginator.previous }}">&laquo; Previous</a> |
+                        {% endif %}
+
+                        <span>Page {{ paginator.current_index }} of {{ paginator.number_pagers }}</span>
+
+                        {% if paginator.next %}
+                            | <a href="{{ paginator.next }}"> Next &raquo;</a>
+                        {% endif %}
+                    </p>
+                </nav>
             {% endblock content %}
         </div>
 

--- a/templates/page.html
+++ b/templates/page.html
@@ -3,7 +3,18 @@
 {% block content %}
 <div class="post">
   <h1 class="post-title">{{ page.title }}</h1>
-  <span class="post-date">{{ page.date | date(format="%Y-%m-%d") }}</span>
+  <span class="post-date">
+	  {{ page.date | date(format="%Y-%m-%d") }}
+	  {% if page.taxonomies.tags %}
+		, tagged
+		{% for tag in page.taxonomies.tags %}
+			<a href="{{ get_taxonomy_url(kind="tags", name=tag) | safe }}">{{ tag }}</a>
+			{% if page.taxonomies.tags | length > 1 %}
+				{% if loop.index != page.taxonomies.tags | length %}, {% endif %}
+			{% endif %}
+		{% endfor %}
+	  {% endif %}
+  </span>
   {{ page.content | safe }}
 </div>
 {% endblock content %}

--- a/templates/section.html
+++ b/templates/section.html
@@ -1,0 +1,18 @@
+{% extends "index.html" %}
+
+{% block content %}
+    <h1>{{ section.title }}</h1>
+    {{ section.content | safe }}
+
+	{% for page in section.pages %}
+	  <div class="post">
+		<h2 class="post-title">
+		  <a href="{{ page.permalink }}">
+			{{ page.title }}
+		  </a>
+		</h2>
+
+		<span class="post-date">{{ page.date | date(format="%Y-%m-%d") }}</span>
+	  </div>
+	{% endfor %}
+{% endblock content %}

--- a/templates/tags/list.html
+++ b/templates/tags/list.html
@@ -1,0 +1,13 @@
+{% extends "index.html" %}
+
+{% block content %}
+    <h1>Tags</h1>
+
+    {% if terms %}
+        <ul>
+            {% for term in terms %}
+                <li><a href="{{ term.permalink | safe }}">{{ term.name }}</a> ({{ term.pages | length }})</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+{% endblock content %}

--- a/templates/tags/single.html
+++ b/templates/tags/single.html
@@ -1,0 +1,9 @@
+{% extends "index.html" %}
+
+{% block content %}
+    <h1>{{ term.name }}</h1>
+
+    {% for page in term.pages %}
+		<a href="{{ page.permalink | safe }}">{{ page.title }}</a>
+    {% endfor %}
+{% endblock content %}


### PR DESCRIPTION
I stole most of the stuff from other themes, so Hyde now have the same functionality as other themes, like tag support and sections.

Also fixed the index page, which was showing everything from oldest to newest and no breaks with the use of Paginator, so now the theme requires the "paginate_by" as After-Dark does.