### PR TITLE
Support iPhone X notch and rounded corners in landscape

### DIFF
--- a/sass/hyde.scss
+++ b/sass/hyde.scss
@@ -112,6 +112,20 @@ a.sidebar-nav-item:focus {
     bottom: 1rem;
     left:   1rem;
   }
+
+  // The #{} stuff is needed because of https://github.com/sass/sass/issues/2378
+  @supports(padding: m#{a}x(0px)) {
+    body:not(.layout-reverse) .sidebar-sticky {
+        // Notch is to left of sidebar; pad appropriately
+        padding-left: m#{a}x(1rem, env(safe-area-inset-left));
+    }
+
+    .layout-reverse .sidebar-sticky {
+        // Support iPhone X rounded corners and notch in landscape
+        // Notch is to right of sidebar; pad appropriately
+        padding-right: m#{a}x(1rem, env(safe-area-inset-right));
+    }
+  }
 }
 
 
@@ -125,6 +139,19 @@ a.sidebar-nav-item:focus {
   padding-top:    4rem;
   padding-bottom: 4rem;
 }
+
+@supports(padding: m#{a}x(0px)) {
+  body:not(.layout-reverse) .content {
+      // Notch is to right of content text; pad it appropriately
+      padding-right: m#{a}x(1rem, env(safe-area-inset-right));
+  }
+
+  .layout-reverse .content {
+      // Notch is to left of content text; pad it appropriately
+      padding-left: m#{a}x(1rem, env(safe-area-inset-left));
+  }
+}
+
 
 @media (min-width: 48em) {
   .content {

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,8 @@
       <meta http-equiv="content-type" content="text/html; charset=utf-8">
 
       <!-- Enable responsiveness on mobile devices-->
-      <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
+      <!-- viewport-fit=cover is to support iPhone X rounded corners and notch in landscape-->
+      <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, viewport-fit=cover">
 
       <title>{% block title %}{{ config.title }}{% endblock title %}</title>
 


### PR DESCRIPTION
Hi! This is a great theme and I'm happily using it as the base for my little site, thank you for porting it :)

I noticed that it didn't support the notch and rounded corners on my iPhone X(R) properly, so I looked up how to go about [fixing that](https://webkit.org/blog/7929/designing-websites-for-iphone-x/) and did so. I figured it would be nice to contribute this back as it is something that everyone could benefit from.

A couple of screenshots (ignore the change to the date format, that's not in this PR):

Before the changes in this PR, normal layout:

![IMG_1339](https://user-images.githubusercontent.com/13814214/54967203-32827f80-4f4d-11e9-8891-1e9a9b5e30b0.PNG)

After the changes in this PR, normal layout:

![IMG_1338](https://user-images.githubusercontent.com/13814214/54967206-32827f80-4f4d-11e9-9152-bcff205b9798.PNG)

After the changes in this PR, reverse layout:

![IMG_1337](https://user-images.githubusercontent.com/13814214/54967207-32827f80-4f4d-11e9-97b7-a9c783a98d4d.PNG)

I know it's hard to visualize without being able to see the notch and corners, but keep in mind that all of those images have the same dimensions. Notice that after the changes, the sidebar extends all the way to the edge and the content text has more space.

Let me know if you have any questions or concerns!


