### PR TITLE
Add 404 template matching the original hyde theme

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,8 @@
+{% extends "index.html" %}
+
+{% block content %}
+<div class="post">
+  <h1 class="post-title">404: Page not found</h1>
+  Sorry, we've misplaced that URL or it's pointing to something that doesn't exist. <a href={{ config.base_url }}>Head back home</a> to try finding it again.</p>
+</div>
+{% endblock content %}


### PR DESCRIPTION
After https://github.com/getzola/zola/issues/571 was closed, this provides a 404 page like the original theme.
Solves #16 