### PR TITLE
Allow posts with no date field for sections sorted by date.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -57,8 +57,9 @@
                             {{ page.title }}
                           </a>
                         </h1>
-
-                        <span class="post-date">{{ page.date | date(format="%Y-%m-%d") }}</span>
+                        {% if page.date %}
+                          <span class="post-date">{{ page.date | date(format="%Y-%m-%d") }}</span>
+                        {% endif %}
                       </div>
                     {% endfor %}
                 </div>

--- a/templates/page.html
+++ b/templates/page.html
@@ -3,8 +3,10 @@
 {% block content %}
 <div class="post">
   <h1 class="post-title">{{ page.title }}</h1>
-  <span class="post-date">{{ page.date | date(format="%Y-%m-%d") }}</span>
-  {{ page.content | safe }}
+  {% if page.date %}
+    <span class="post-date">{{ page.date | date(format="%Y-%m-%d") }}</span>
+  {% endif %}
+    {{ page.content | safe }}
 </div>
 {% endblock content %}
 


### PR DESCRIPTION
Having `content/_index.md` like this
```
+++
sort_by = "date"
+++
```

Allows to show on home page only posts having a `date` metadata.

Sometimes it is useful to create a `page` like an `/about/` that is not listed on home page but accessible only via link.

Currently hyde is failing because `date` filter requires a date.

