### PR TITLE
Use lang variable instead of hardcoding 'en'

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ lang }}">
     <head>
       <meta http-equiv="X-UA-Compatible" content="IE=edge">
       <meta http-equiv="content-type" content="text/html; charset=utf-8">


### PR DESCRIPTION
If you write in another language, you should have the right `lang` value.