### PR TITLE
Fixed support for pages without dates

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -59,7 +59,7 @@
                           </a>
                         </h1>
 
-                        <span class="post-date">{{ page.date | date(format="%Y-%m-%d") }}</span>
+                        {% if page.date %}<span class="post-date">{{ page.date | date(format="%Y-%m-%d") }}</span>{% endif -%}
                       </div>
                     {% endfor %}
                 </div>

--- a/templates/page.html
+++ b/templates/page.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="post">
   <h1 class="post-title">{{ page.title }}</h1>
-  <span class="post-date">{{ page.date | date(format="%Y-%m-%d") }}</span>
+  {% if page.date %}<span class="post-date">{{ page.date | date(format="%Y-%m-%d") }}</span>{% endif -%}
   {{ page.content | safe }}
 </div>
 {% endblock content %}


### PR DESCRIPTION
I was getting errors as my pages didn't have dates. I'm using this theme for a website rather than blog